### PR TITLE
test: move common functions into test lib

### DIFF
--- a/test/apply.t
+++ b/test/apply.t
@@ -10,13 +10,6 @@ test_description='Test git reintegrage apply option'
 
 . ./test-lib.sh
 
-commit_file() {
-	local filename="$1"
-	echo "$2" > $filename &&
-	git add -f $filename &&
-	git commit -q -m "commit $filename"
-}
-
 test_expect_success 'setup branches' '
 	git init -q &&
 	commit_file base base &&

--- a/test/conflicts.t
+++ b/test/conflicts.t
@@ -11,18 +11,6 @@ test_description='Test git reintegrage branches with no conflicts'
 
 . ./test-lib.sh
 
-commit_file() {
-	local filename="$1"
-	echo "$2" > $filename &&
-	git add -f $filename &&
-	git commit -q -m "commit $filename"
-}
-
-write_script() {
-	cat > "$1" &&
-	chmod +x "$1"
-}
-
 test_expect_success 'setup branches' '
 	git init -q &&
 	commit_file base base &&

--- a/test/fixup.t
+++ b/test/fixup.t
@@ -11,18 +11,6 @@ test_description='Test the "fixup" instruction'
 
 . ./test-lib.sh
 
-commit_file() {
-	local filename="$1"
-	echo "$2" > $filename &&
-	git add -f $filename &&
-	git commit -q -m "commit $filename"
-}
-
-write_script() {
-	cat > "$1" &&
-	chmod +x "$1"
-}
-
 test_expect_success 'setup branches' '
 	git init -q &&
 	commit_file base base &&

--- a/test/reintegrate.t
+++ b/test/reintegrate.t
@@ -11,18 +11,6 @@ test_description="Test git reintegrate"
 
 . ./test-lib.sh
 
-commit_file() {
-	local filename="$1"
-	echo "$2" > $filename &&
-	git add -f $filename &&
-	git commit -q -m "commit $filename"
-}
-
-write_script() {
-	cat > "$1" &&
-	chmod +x "$1"
-}
-
 test_expect_success 'setup branches' '
 	git init -q &&
 	commit_file base base &&

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -8,3 +8,15 @@ GIT_COMMITTER_EMAIL=committer@example.com
 GIT_COMMITTER_NAME='C O Mitter'
 export GIT_AUTHOR_EMAIL GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL GIT_COMMITTER_NAME
+
+commit_file() {
+	local filename="$1"
+	echo "$2" > $filename &&
+	git add -f $filename &&
+	git commit -q -m "commit $filename"
+}
+
+write_script() {
+	cat > "$1" &&
+	chmod +x "$1"
+}


### PR DESCRIPTION
Moved duplicated function definitions to the test-lib.sh file, so that maintenance is lessened.
